### PR TITLE
[docs] : github에서 jira로 이슈 연동 가능한 설정 추가

### DIFF
--- a/.github/ISSUE_TEMPLATE/issue-form.yml
+++ b/.github/ISSUE_TEMPLATE/issue-form.yml
@@ -1,0 +1,55 @@
+name: '이슈 생성'
+description: 'Repo에 이슈를 생성하며, 생성된 이슈는 Jira와 연동됩니다.'
+labels: [feat]
+title: '이슈 이름을 작성해주세요'
+body:
+  - type: input
+    id: parentKey
+    attributes:
+      label: '🎟️ 상위 작업 (Ticket Number)'
+      description: '상위 작업의 Ticket Number를 기입해주세요'
+      placeholder: 'PRJ-00'
+    validations:
+      required: true
+
+  - type: dropdown
+    id: branchType
+    attributes:
+      label: '📂 브랜치 타입 (Branch Type)'
+      description: '브랜치 타입을 선택해주세요'
+      options:
+        - feature
+        - style
+        - fix
+        - refactor
+        - docs
+        - chore
+    validations:
+      required: true
+
+  - type: input
+    id: branch
+    attributes:
+      label: '🌳 브랜치명 (Branch)'
+      description: '영어로 브랜치명을 작성해주세요'
+    validations:
+      required: true
+
+  - type: input
+    id: description
+    attributes:
+      label: '📝 상세 내용(Description)'
+      description: '이슈에 대해서 간략히 설명해주세요'
+    validations:
+      required: true
+
+  - type: textarea
+    id: tasks
+    attributes:
+      label: '✅ 체크리스트(Tasks)'
+      description: '해당 이슈에 대해 필요한 작업목록을 작성해주세요'
+      value: |
+        - [ ] Task1
+        - [ ] Task2
+    validations:
+      required: true

--- a/.github/workflows/close-jira-issue.yml
+++ b/.github/workflows/close-jira-issue.yml
@@ -1,0 +1,35 @@
+name: Close Jira issue
+on:
+  issues:
+    types:
+      - closed
+
+jobs:
+  close-issue:
+    name: Close Jira issue
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Login to Jira
+        uses: atlassian/gajira-login@v3
+        env:
+          JIRA_BASE_URL: ${{ secrets.JIRA_BASE_URL }}
+          JIRA_API_TOKEN: ${{ secrets.JIRA_API_TOKEN }}
+          JIRA_USER_EMAIL: ${{ secrets.JIRA_USER_EMAIL }}
+
+      - name: Extract Jira issue key from GitHub issue title
+        id: extract-key
+        run: |
+          ISSUE_TITLE="${{ github.event.issue.title }}"
+          # 알파벳/숫자/하이픈만 허용하여 필터링
+          SAFE_TITLE=$(echo "$ISSUE_TITLE" | tr -cd '[:alnum:]- ')
+          # 패턴 미매칭 시에도 스크립트가 종료되지 않도록 처리
+          JIRA_KEY=$(echo "$SAFE_TITLE" | grep -oE '[A-Z]+-[0-9]+' || true)
+          echo "JIRA_KEY=$JIRA_KEY" >> $GITHUB_ENV
+
+      - name: Close Jira issue
+        if: env.JIRA_KEY != ''
+        uses: atlassian/gajira-transition@v3
+        with:
+          issue: ${{ env.JIRA_KEY }}
+          transition: 완료

--- a/.github/workflows/create-jira-issue.yml
+++ b/.github/workflows/create-jira-issue.yml
@@ -1,0 +1,97 @@
+name: Create Jira issue
+on:
+  issues:
+    types:
+      - opened
+
+permissions:
+  contents: write
+  issues: write
+
+jobs:
+  create-issue:
+    name: Create Jira issue
+    runs-on: ubuntu-latest
+    steps:
+      - name: Login
+        uses: atlassian/gajira-login@v3
+        env:
+          JIRA_BASE_URL: ${{ secrets.JIRA_BASE_URL }}
+          JIRA_API_TOKEN: ${{ secrets.JIRA_API_TOKEN }}
+          JIRA_USER_EMAIL: ${{ secrets.JIRA_USER_EMAIL }}
+
+      - name: Checkout main code
+        uses: actions/checkout@v4
+        with:
+          ref: main
+
+      - name: Issue Parser
+        uses: stefanbuck/github-issue-parser@v3
+        id: issue-parser
+        with:
+          template-path: .github/ISSUE_TEMPLATE/issue-form.yml
+
+      - name: Log Issue Parser
+        run: |
+          echo '${{ steps.issue-parser.outputs.issueparser_parentKey }}'
+          echo '${{ steps.issue-parser.outputs.__ticket_number }}'
+          echo '${{ steps.issue-parser.outputs.jsonString }}'
+
+      - name: Convert markdown to Jira Syntax
+        uses: peter-evans/jira2md@v1
+        id: md2jira
+        with:
+          input-text: |
+            ### Github Issue Link
+            - ${{ github.event.issue.html_url }}
+
+            ${{ github.event.issue.body }}
+          mode: md2jira
+
+      - name: Create Issue
+        id: create
+        uses: atlassian/gajira-create@v3
+        with:
+          project: SCRUM
+          issuetype: Task
+          summary: '${{ github.event.issue.title }}'
+          description: '${{ steps.md2jira.outputs.output-text }}'
+          fields: |
+            {
+              "parent": {
+                "key": "${{ steps.issue-parser.outputs.issueparser_parentKey }}"
+              }
+            }
+
+      - name: Log created issue
+        run: echo "Jira Issue ${{ steps.issue-parser.outputs.issueparser_parentKey }}/${{ steps.create.outputs.issue }} was created"
+
+      - name: Checkout develop code
+        uses: actions/checkout@v4
+        with:
+          ref: develop
+
+      - name: Create branch with Ticket number and type
+        run: |
+          ISSUE_NUMBER="${{ steps.create.outputs.issue }}"
+          BRANCH_TYPE="${{ steps.issue-parser.outputs.issueparser_branchType }}"
+          ISSUE_TITLE="${{ steps.issue-parser.outputs.issueparser_branch }}"
+          SLUG_TITLE=$(echo "${ISSUE_TITLE}" | sed 's/ /-/g' | tr '[:upper:]' '[:lower:]')
+          BRANCH_NAME="${BRANCH_TYPE}/${ISSUE_NUMBER}-${SLUG_TITLE}"
+          git checkout -b "${BRANCH_NAME}"
+          git push origin "${BRANCH_NAME}"
+
+      - name: Update issue title
+        uses: actions-cool/issues-helper@v3
+        with:
+          actions: 'update-issue'
+          token: ${{ secrets.GITHUB_TOKEN }}
+          title: '[${{ steps.create.outputs.issue }}] ${{ github.event.issue.title }}'
+
+      - name: Add comment with Jira issue link
+        uses: actions-cool/issues-helper@v3
+        with:
+          actions: 'create-comment'
+          token: ${{ secrets.GITHUB_TOKEN }}
+          issue-number: ${{ github.event.issue.number }}
+          body: 'Jira Issue Created: [${{ steps.create.outputs.issue }}](${{ secrets.JIRA_BASE_URL }}/browse/${{ steps.create.outputs.issue }})'


### PR DESCRIPTION
## 💡 PR 제목
[type] : <기능 또는 변경 요약>

## ✨ 주요 변경 사항

- 어떤 기능이 추가되었고, 어떤 이슈/버그가 해결되었는지 간결하고 명확하게 설명해주세요.

fe github에 이슈 생성 시 jira로 바로 이슈를 생성할 수 있는 템플릿 설정을 추가했습니다.
그에 따라 be도 설정 파일을 추가했습니다.

## 🔗 관련 이슈
- 연결된 이슈 번호를 입력해주세요 (예: `#42`)
- 없을 경우 생략 가능

## 🔧 PR 종류 (하나만 선택해주세요)
- [ ] 기능 개선 (기존 기능의 동작/성능 향상)
- [ ] 새로운 기능 추가 (신규 도메인, 기능 등)
- [ ] 리팩토링 (동작 변경 없음, 구조 개선)
- [x] 문서 수정 (README, API 문서 등)
- [ ] 테스트 추가 / 수정
- [ ] 인프라 구성 변경 (Kafka, AWS 리소스 등)
- [ ] 기타

## 📗 참고 자료 (선택)

## 📢 리뷰 요구 사항 (선택)

## ✅ 셀프 체크리스트
- [x] PR 제목을 형식에 맞게 작성했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요?
- [ ] Assignees, Reviewers, Labels 를 등록했나요?
- [ ] 작업 도중 문서 수정이 필요한 경우 잘 수정했나요?
- [ ] 직접 기능 테스트를 진행했나요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * GitHub 이슈 생성 시 Jira 이슈와 연동되는 이슈 템플릿이 추가되었습니다.
  * GitHub 이슈 생성 시 자동으로 Jira 이슈 생성 및 관련 브랜치가 생성됩니다.
  * GitHub 이슈가 종료될 때 해당 Jira 이슈가 자동으로 "완료" 상태로 전환됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->