### PR TITLE
[refactor] : 지역화폐 충전 로직에서 VO 변환시 createdAt, updatedAt 필드 제거

### DIFF
--- a/src/main/java/org/danji/transaction/converter/TransactionConverter.java
+++ b/src/main/java/org/danji/transaction/converter/TransactionConverter.java
@@ -27,8 +27,6 @@ public class TransactionConverter {
                 .type(type)
                 .comment(comment)
                 .ownerWalletId(ownerWalletId)
-                .createdAt(LocalDateTime.now())
-                .updatedAt(LocalDateTime.now())
                 .build();
     }
 

--- a/src/main/resources/org/danji/transaction/mapper/TransactionMapper.xml
+++ b/src/main/resources/org/danji/transaction/mapper/TransactionMapper.xml
@@ -30,8 +30,8 @@
                    #{type},
                    #{comment},
                    #{ownerWalletId},
-                   #{createdAt},
-                   #{updatedAt}
+                   now(),
+                   now()
                )
     </insert>
 


### PR DESCRIPTION
## ✨ 주요 변경 사항

- 지역화폐 충전 VO 변환시 createdAt, updatedAt 필드 제거

## 🔗 관련 이슈
- #41 

## 🔧 PR 종류 (하나만 선택해주세요)
- [ ] 기능 개선 (기존 기능의 동작/성능 향상)
- [ ] 새로운 기능 추가 (신규 도메인, 기능 등)
- [ ] 리팩토링 (동작 변경 없음, 구조 개선)
- [ ] 문서 수정 (README, API 문서 등)
- [ ] 테스트 추가 / 수정
- [ ] 인프라 구성 변경 (Kafka, AWS 리소스 등)
- [ ] 기타

## 📗 참고 자료 (선택)

## 📢 리뷰 요구 사항 (선택)

## ✅ 셀프 체크리스트
- [ ] PR 제목을 형식에 맞게 작성했나요?
- [ ] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요?
- [ ] Assignees, Reviewers, Labels 를 등록했나요?
- [ ] 작업 도중 문서 수정이 필요한 경우 잘 수정했나요?
- [ ] 직접 기능 테스트를 진행했나요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * 거래 생성 시 생성일과 수정일이 데이터베이스에서 자동으로 현재 시각으로 설정되도록 개선되었습니다.  
* **리팩터**
  * 내부 로직에서 타임스탬프를 직접 설정하지 않도록 변경되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->