### PR TITLE
fix: 트랜잭션 조회 시 통계 값 반환 추가

### DIFF
--- a/src/main/java/org/danji/localCurrency/mapper/LocalCurrencyMapper.java
+++ b/src/main/java/org/danji/localCurrency/mapper/LocalCurrencyMapper.java
@@ -17,4 +17,6 @@ public interface LocalCurrencyMapper {
 
     void create(LocalCurrencyVO localCurrency);
 
+    LocalCurrencyVO findByWalletId(UUID walletId);
+
 }

--- a/src/main/java/org/danji/transaction/controller/TransactionController.java
+++ b/src/main/java/org/danji/transaction/controller/TransactionController.java
@@ -7,6 +7,7 @@ import org.danji.global.common.ApiResponse;
 import org.danji.transaction.dto.request.PaymentDTO;
 import org.danji.transaction.dto.request.TransactionFilterDTO;
 import org.danji.transaction.dto.request.TransferDTO;
+import org.danji.transaction.dto.response.TransactionAggregateDTO;
 import org.danji.transaction.dto.response.TransactionDTO;
 import org.danji.transaction.service.TransactionService;
 import org.springframework.http.HttpStatus;
@@ -42,8 +43,9 @@ public class TransactionController {
     }
 
     @GetMapping("/wallets/{walletId}/transactions")
-    public ResponseEntity<ApiResponse<List<TransactionDTO>>> getTransactions(@PathVariable UUID walletId, @ModelAttribute TransactionFilterDTO transactionFilterDTO) {
-        List<TransactionDTO> result = transactionService.getTransactionsByWalletId(walletId, transactionFilterDTO);
+    public ResponseEntity<ApiResponse<TransactionAggregateDTO>> getTransactions(@PathVariable UUID walletId, @ModelAttribute TransactionFilterDTO transactionFilterDTO) {
+        transactionFilterDTO.setWalletId(walletId);
+        TransactionAggregateDTO result = transactionService.getTransactionAggregate(transactionFilterDTO);
         return ResponseEntity.status(HttpStatus.OK).body(ApiResponse.success(result));
     }
 }

--- a/src/main/java/org/danji/transaction/converter/TransactionConverter.java
+++ b/src/main/java/org/danji/transaction/converter/TransactionConverter.java
@@ -41,6 +41,8 @@ public class TransactionConverter {
                 .type(transactionVO.getType())
                 .comment(transactionVO.getComment())
                 .ownerWalletId(transactionVO.getOwnerWalletId())
+                .createdAt(transactionVO.getCreatedAt())
+                .updatedAt(transactionVO.getUpdatedAt())
                 .build();
     }
 

--- a/src/main/java/org/danji/transaction/dto/response/TransactionAggregateDTO.java
+++ b/src/main/java/org/danji/transaction/dto/response/TransactionAggregateDTO.java
@@ -1,0 +1,20 @@
+package org.danji.transaction.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Data
+public class TransactionAggregateDTO {
+
+    private Integer aggregateCharge;
+    private Integer aggregateIncentive;
+
+    private List<TransactionDTO> transactions;
+}

--- a/src/main/java/org/danji/transaction/dto/response/TransactionDTO.java
+++ b/src/main/java/org/danji/transaction/dto/response/TransactionDTO.java
@@ -9,11 +9,12 @@ import org.danji.transaction.enums.Type;
 
 import java.util.UUID;
 
+@EqualsAndHashCode(callSuper = true)
 @NoArgsConstructor
 @AllArgsConstructor
-@Builder
+@SuperBuilder
 @Data
-public class TransactionDTO{
+public class TransactionDTO extends BaseDTO{
     private UUID transactionId;
     private UUID fromWalletId;
     private UUID toWalletId;

--- a/src/main/java/org/danji/transaction/service/TransactionService.java
+++ b/src/main/java/org/danji/transaction/service/TransactionService.java
@@ -3,6 +3,7 @@ package org.danji.transaction.service;
 import org.danji.transaction.dto.request.PaymentDTO;
 import org.danji.transaction.dto.request.TransactionFilterDTO;
 import org.danji.transaction.dto.request.TransferDTO;
+import org.danji.transaction.dto.response.TransactionAggregateDTO;
 import org.danji.transaction.dto.response.TransactionDTO;
 
 import java.util.List;
@@ -14,5 +15,5 @@ public interface TransactionService {
 
     List<TransactionDTO> handlePayment(PaymentDTO paymentDTO);
 
-    List<TransactionDTO> getTransactionsByWalletId(UUID walletId, TransactionFilterDTO transactionFilterDTO);
+    TransactionAggregateDTO getTransactionAggregate(TransactionFilterDTO transactionFilterDTO);
 }

--- a/src/main/java/org/danji/transaction/service/TransactionServiceImpl.java
+++ b/src/main/java/org/danji/transaction/service/TransactionServiceImpl.java
@@ -2,40 +2,24 @@ package org.danji.transaction.service;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j2;
-import net.bytebuddy.asm.Advice;
-import org.danji.cashback.converter.CashbackConverter;
-import org.danji.cashback.domain.CashbackVO;
-import org.danji.cashback.enums.CashBackStatus;
-import org.danji.cashback.mapper.CashbackMapper;
-import org.danji.global.error.ErrorCode;
 import org.danji.localCurrency.domain.LocalCurrencyVO;
 import org.danji.localCurrency.enums.BenefitType;
-
-import org.danji.localCurrency.exception.LocalCurrencyException;
 import org.danji.localCurrency.mapper.LocalCurrencyMapper;
 import org.danji.transaction.converter.TransactionConverter;
 import org.danji.transaction.domain.TransactionVO;
 import org.danji.transaction.dto.request.PaymentDTO;
 import org.danji.transaction.dto.request.TransactionFilterDTO;
 import org.danji.transaction.dto.request.TransferDTO;
+import org.danji.transaction.dto.response.TransactionAggregateDTO;
 import org.danji.transaction.dto.response.TransactionDTO;
-import org.danji.transaction.enums.Direction;
 import org.danji.transaction.enums.Type;
-import org.danji.transaction.exception.TransactionException;
 import org.danji.transaction.mapper.TransactionMapper;
 import org.danji.transaction.processor.TransferProcessor;
-import org.danji.wallet.domain.WalletVO;
-import org.danji.wallet.exception.WalletException;
-import org.danji.wallet.mapper.WalletMapper;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.time.LocalDateTime;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
-import java.util.UUID;
-import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -45,27 +29,49 @@ public class TransactionServiceImpl implements TransactionService {
     private final Map<String, TransferProcessor> processorMap;
     private final TransactionMapper transactionMapper;
     private final TransactionConverter transactionConverter;
+    private final LocalCurrencyMapper localCurrencyMapper;
 
     @Transactional
     @Override
-    public List<TransactionDTO> handleTransfer(TransferDTO transferDTO){
+    public List<TransactionDTO> handleTransfer(TransferDTO transferDTO) {
         TransferProcessor<TransferDTO> processor = processorMap.get(transferDTO.getType().name());
 
         return processor.process(transferDTO);
     }
 
-    public List<TransactionDTO> handlePayment(PaymentDTO paymentDTO){
+    public List<TransactionDTO> handlePayment(PaymentDTO paymentDTO) {
         TransferProcessor<PaymentDTO> processor = processorMap.get("PAYMENT");
         return processor.process(paymentDTO);
     }
 
     @Override
-    public List<TransactionDTO> getTransactionsByWalletId(UUID walletId, TransactionFilterDTO transactionFilterDTO) {
-        transactionFilterDTO.setWalletId(walletId);
+    public TransactionAggregateDTO getTransactionAggregate(TransactionFilterDTO transactionFilterDTO) {
 
-        List<TransactionVO> transactionVOList = transactionMapper.findByFilter(transactionFilterDTO);
-        return transactionVOList.stream()
-                .map(transactionConverter::toTransactionDTO)
-                .collect(Collectors.toList());
+        List<TransactionDTO> transactionList = fetchTransactions(transactionFilterDTO);
+
+        int totalCharge = calculateTotalWithType(transactionList, Type.CHARGE);
+        LocalCurrencyVO localCurrencyVO = localCurrencyMapper.findByWalletId(transactionFilterDTO.getWalletId());
+        Integer percentage = localCurrencyVO.getPercentage();
+
+        return TransactionAggregateDTO.builder()
+                .transactions(transactionList)
+                .aggregateCharge(totalCharge)
+                .aggregateIncentive(totalCharge * percentage / 100)
+                .build();
     }
+
+    private List<TransactionDTO> fetchTransactions(TransactionFilterDTO filterDto) {
+        return transactionMapper
+                .findByFilter(filterDto).stream()
+                .map(transactionConverter::toTransactionDTO)
+                .toList();
+    }
+
+    private int calculateTotalWithType(List<TransactionDTO> transactions, Type type) {
+        return transactions.stream()
+                .filter(dto -> dto.getType() == type)
+                .mapToInt(TransactionDTO::getAmount)
+                .sum();
+    }
+
 }

--- a/src/main/resources/org/danji/localCurrency/mapper/LocalCurrencyMapper.xml
+++ b/src/main/resources/org/danji/localCurrency/mapper/LocalCurrencyMapper.xml
@@ -5,18 +5,24 @@
 
 <mapper namespace="org.danji.localCurrency.mapper.LocalCurrencyMapper">
     <insert id="create">
-        insert into local_currency(local_currency_id, region_id, name, benefit_type, maximum, percentage, created_at, updated_at)
+        insert into local_currency(local_currency_id, region_id, name, benefit_type, maximum, percentage, created_at,
+                                   updated_at)
             value (#{localCurrencyId}, #{regionId}, #{name}, #{benefitType}, #{maximum}, #{percentage}, now(), now())
     </insert>
 
 
     <select id="findById" resultMap="LocalCurrencyMap">
-        select * from local_currency where local_currency_id = #{localCurrencyId}
+        select *
+        from local_currency
+        where local_currency_id = #{localCurrencyId}
     </select>
 
     <select id="findByRegionId" resultMap="LocalCurrencyMap">
-        select * from local_currency where region_id = #{regionId}
+        select *
+        from local_currency
+        where region_id = #{regionId}
     </select>
+
     <select id="findAllByName" resultType="org.danji.localCurrency.domain.LocalCurrencyVO">
         SELECT *
         FROM local_currency
@@ -46,6 +52,20 @@
         </where>
     </select>
 
+    <select id="findByWalletId" resultMap="LocalCurrencyMap">
+        SELECT lc.local_currency_id,
+               lc.region_id,
+               lc.name,
+               lc.benefit_type,
+               lc.maximum,
+               lc.percentage,
+               lc.created_at,
+               lc.updated_at
+        FROM wallet w
+                 INNER JOIN local_currency lc
+                            ON w.local_currency_id = lc.local_currency_id
+        WHERE w.wallet_id = #{walletId}
+    </select>
 
     <resultMap id="LocalCurrencyMap" type="LocalCurrencyVO">
         <id property="localCurrencyId" column="local_currency_id"/>

--- a/src/main/resources/org/danji/transaction/mapper/TransactionMapper.xml
+++ b/src/main/resources/org/danji/transaction/mapper/TransactionMapper.xml
@@ -5,37 +5,33 @@
 
 <mapper namespace="org.danji.transaction.mapper.TransactionMapper">
     <insert id="insert" parameterType="TransactionVO">
-        INSERT INTO transaction (
-            transaction_id
-            ,from_wallet_id
-            ,to_wallet_id
-            ,before_balance
-            ,after_balance
-            ,amount
-            ,direction
-            ,type
-            ,comment
-            ,owner_wallet_id
-            ,created_at
-            ,updated_at
-        )
-        VALUES (
-                   #{transactionId},
-                   #{fromWalletId},
-                   #{toWalletId},
-                   #{beforeBalance},
-                   #{afterBalance},
-                   #{amount},
-                   #{direction},
-                   #{type},
-                   #{comment},
-                   #{ownerWalletId},
-                   now(),
-                   now()
-               )
+        INSERT INTO transaction ( transaction_id
+                                , from_wallet_id
+                                , to_wallet_id
+                                , before_balance
+                                , after_balance
+                                , amount
+                                , direction
+                                , type
+                                , comment
+                                , owner_wallet_id
+                                , created_at
+                                , updated_at)
+        VALUES (#{transactionId},
+                #{fromWalletId},
+                #{toWalletId},
+                #{beforeBalance},
+                #{afterBalance},
+                #{amount},
+                #{direction},
+                #{type},
+                #{comment},
+                #{ownerWalletId},
+                now(),
+                now())
     </insert>
 
-    <select id = "findByFilter" resultType="TransactionVO">
+    <select id="findByFilter" resultType="TransactionVO">
         SELECT *
         FROM transaction
         WHERE owner_wallet_id = #{filter.walletId}
@@ -46,11 +42,8 @@
         </if>
 
         <choose>
-            <when test="filter.sortOrder.name() == 'DESC'">
-                ORDER BY created_at DESC
-            </when>
-            <when test="filter.sortOrder.name() == 'ASC'">
-                ORDER BY created_at ASC
+            <when test="filter.sortOrder != null">
+                ORDER BY created_at ${filter.sortOrder.name()}
             </when>
             <otherwise>
                 ORDER BY created_at DESC


### PR DESCRIPTION
## 💡 PR 제목
[type] : <기능 또는 변경 요약>

## ✨ 주요 변경 사항

- 어떤 기능이 추가되었고, 어떤 이슈/버그가 해결되었는지 간결하고 명확하게 설명해주세요.

결제 내역 조회 시 이번 달 충전 금액, 받은 인센티브 같이 표기 

## 🔗 관련 이슈
- 연결된 이슈 번호를 입력해주세요 (예: `#42`)
- 없을 경우 생략 가능

## 🔧 PR 종류 (하나만 선택해주세요)
- [ ] 기능 개선 (기존 기능의 동작/성능 향상)
- [x] 새로운 기능 추가 (신규 도메인, 기능 등)
- [ ] 리팩토링 (동작 변경 없음, 구조 개선)
- [ ] 문서 수정 (README, API 문서 등)
- [ ] 테스트 추가 / 수정
- [ ] 인프라 구성 변경 (Kafka, AWS 리소스 등)
- [ ] 기타

## 📗 참고 자료 (선택)

## 📢 리뷰 요구 사항 (선택)

## ✅ 셀프 체크리스트
- [ ] PR 제목을 형식에 맞게 작성했나요?
- [ ] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요?
- [ ] Assignees, Reviewers, Labels 를 등록했나요?
- [ ] 작업 도중 문서 수정이 필요한 경우 잘 수정했나요?
- [ ] 직접 기능 테스트를 진행했나요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 거래 내역 조회 시 거래 목록과 함께 총 합계(aggregateCharge) 및 인센티브(aggregateIncentive) 정보를 포함한 응답이 제공됩니다.

* **기능 개선**
  * 거래 조회 API의 응답 형태가 단순 목록에서 집계 정보가 포함된 구조로 변경되었습니다.
  * 거래 DTO에 생성일(createdAt)과 수정일(updatedAt) 정보가 추가되었습니다.

* **버그 수정 및 기타**
  * 일부 쿼리 및 매퍼 XML의 가독성이 향상되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->