### PR TITLE
[feat] : 결제 시, 뱃지 추가 로직 구현

### DIFF
--- a/src/main/java/org/danji/memberBadge/mapper/MemberBadgeMapper.java
+++ b/src/main/java/org/danji/memberBadge/mapper/MemberBadgeMapper.java
@@ -4,6 +4,7 @@ import org.apache.ibatis.annotations.Param;
 import org.danji.memberBadge.domain.MemberBadgeVO;
 import org.danji.memberBadge.dto.MemberBadgeDetailDTO;
 import org.danji.memberBadge.dto.MemberBadgeFilterDTO;
+import org.danji.memberBadge.enums.BadgeGrade;
 
 import java.util.List;
 import java.util.UUID;
@@ -14,7 +15,7 @@ public interface MemberBadgeMapper {
 
     void insert(MemberBadgeVO memberBadge);
 
-    MemberBadgeVO findByMemberIdAndBadgeId(@Param("memberId") UUID memberId, @Param("badgeId") UUID badgeId);
+    MemberBadgeVO findByMemberIdAndBadgeIdAndBadgeGrade(@Param("memberId") UUID memberId, @Param("badgeId") UUID badgeId, @Param("badgeGrade")BadgeGrade badgeGrade);
 
     List<MemberBadgeDetailDTO> findByFilter(MemberBadgeFilterDTO filter);
 }

--- a/src/main/java/org/danji/memberBadge/service/MemberBadgeService.java
+++ b/src/main/java/org/danji/memberBadge/service/MemberBadgeService.java
@@ -3,6 +3,7 @@ package org.danji.memberBadge.service;
 import org.danji.memberBadge.dto.MemberBadgeCreateDTO;
 import org.danji.memberBadge.dto.MemberBadgeDetailDTO;
 import org.danji.memberBadge.dto.MemberBadgeFilterDTO;
+import org.danji.memberBadge.enums.BadgeGrade;
 
 import java.util.List;
 import java.util.UUID;
@@ -14,4 +15,6 @@ public interface MemberBadgeService {
     MemberBadgeDetailDTO getMemberBadge(UUID memberBadgeId);
 
     List<MemberBadgeDetailDTO> getMemberBadgeList(MemberBadgeFilterDTO filter);
+
+    Boolean validateMemberBadge(UUID memberId, UUID badgeId, BadgeGrade badgeGrade);
 }

--- a/src/main/java/org/danji/memberBadge/service/MemberBadgeServiceImpl.java
+++ b/src/main/java/org/danji/memberBadge/service/MemberBadgeServiceImpl.java
@@ -6,6 +6,7 @@ import org.danji.memberBadge.domain.MemberBadgeVO;
 import org.danji.memberBadge.dto.MemberBadgeCreateDTO;
 import org.danji.memberBadge.dto.MemberBadgeDetailDTO;
 import org.danji.memberBadge.dto.MemberBadgeFilterDTO;
+import org.danji.memberBadge.enums.BadgeGrade;
 import org.danji.memberBadge.exception.MemberBadgeException;
 import org.danji.memberBadge.mapper.MemberBadgeMapper;
 import org.springframework.stereotype.Service;
@@ -23,7 +24,7 @@ public class MemberBadgeServiceImpl implements MemberBadgeService {
     @Override
     @Transactional
     public MemberBadgeDetailDTO createMemberBadge(MemberBadgeCreateDTO createDTO) {
-        validateMemberBadge(createDTO.getMemberId(), createDTO.getBadgeId());
+        //validateMemberBadge(createDTO.getMemberId(), createDTO.getBadgeId());
         MemberBadgeVO vo = createDTO.toVo();
 
         UUID memberBadgeId = UUID.randomUUID();
@@ -48,10 +49,11 @@ public class MemberBadgeServiceImpl implements MemberBadgeService {
     }
 
 
-    private void validateMemberBadge(UUID memberId, UUID badgeId) {
-        MemberBadgeVO vo = mapper.findByMemberIdAndBadgeId(memberId, badgeId);
+    public Boolean validateMemberBadge(UUID memberId, UUID badgeId, BadgeGrade badgeGrade) {
+        MemberBadgeVO vo = mapper.findByMemberIdAndBadgeIdAndBadgeGrade(memberId, badgeId, badgeGrade);
         if (vo != null) {
-            throw new MemberBadgeException(ErrorCode.DUPLICATED_MEMBER_BADGE);
+            return false;
         }
+        return true;
     }
 }

--- a/src/main/java/org/danji/transaction/strategy/LocalStrategy.java
+++ b/src/main/java/org/danji/transaction/strategy/LocalStrategy.java
@@ -4,7 +4,17 @@ import lombok.RequiredArgsConstructor;
 import org.danji.availableMerchant.domain.AvailableMerchantVO;
 import org.danji.availableMerchant.exception.AvailableMerchantException;
 import org.danji.availableMerchant.mapper.AvailableMerchantMapper;
+import org.danji.badge.domain.BadgeVO;
+import org.danji.badge.dto.BadgeFilterDTO;
+import org.danji.badge.enums.BadgeType;
+import org.danji.badge.mapper.BadgeMapper;
 import org.danji.global.error.ErrorCode;
+import org.danji.localCurrency.domain.LocalCurrencyVO;
+import org.danji.localCurrency.exception.LocalCurrencyException;
+import org.danji.localCurrency.mapper.LocalCurrencyMapper;
+import org.danji.memberBadge.dto.MemberBadgeCreateDTO;
+import org.danji.memberBadge.enums.BadgeGrade;
+import org.danji.memberBadge.service.MemberBadgeService;
 import org.danji.transaction.converter.TransactionConverter;
 import org.danji.transaction.domain.TransactionVO;
 import org.danji.transaction.dto.request.PaymentDTO;
@@ -31,10 +41,17 @@ import static org.danji.transaction.validator.WalletValidator.checkOwnership;
 @RequiredArgsConstructor
 public class LocalStrategy implements PaymentStrategy {
 
+    private static final int bronze_criteria = 50000;
+    private static final int silver_criteria = 100000;
+    private static final int gold_criteria = 200000;
+
     private final AvailableMerchantMapper availableMerchantMapper;
     private final WalletMapper walletMapper;
     private final TransactionConverter transactionConverter;
     private final TransactionMapper transactionMapper;
+    private final LocalCurrencyMapper localCurrencyMapper;
+    private final BadgeMapper badgeMapper;
+    private final MemberBadgeService memberBadgeService;
 
     @Override
     public boolean supports(PaymentDTO paymentDTO) {
@@ -58,7 +75,10 @@ public class LocalStrategy implements PaymentStrategy {
         if (LocalCurrencyWalletVO == null) {
             throw new WalletException(ErrorCode.WALLET_NOT_FOUND);
         }
-
+        LocalCurrencyVO localCurrencyVO = localCurrencyMapper.findById(LocalCurrencyWalletVO.getLocalCurrencyId());
+        if (localCurrencyVO == null) {
+            throw new LocalCurrencyException(ErrorCode.LOCAL_CURRENCY_NOT_FOUND);
+        }
         WalletFilterDTO walletFilterDTO = WalletFilterDTO.builder().memberId(userId).walletType(WalletType.LOCAL).build();
         List<WalletVO> localWalletByUserIdVO = walletMapper.findByFilter(walletFilterDTO);
         if (!checkOwnership(localWalletByUserIdVO, LocalCurrencyWalletVO)) {
@@ -71,6 +91,55 @@ public class LocalStrategy implements PaymentStrategy {
 
         walletMapper.updateWalletBalance(LocalCurrencyWalletVO.getWalletId(), -paymentDTO.getMerchantAmount());
         walletMapper.updateWalletTotalPayment(LocalCurrencyWalletVO.getWalletId(), paymentDTO.getInputAmount());
+
+        int paymentAmount = LocalCurrencyWalletVO.getTotalPayment() + paymentDTO.getInputAmount();
+
+        if (paymentAmount > bronze_criteria && paymentAmount < silver_criteria){
+            BadgeFilterDTO badgeFilterDTO = BadgeFilterDTO.builder().badgeType(BadgeType.NORMAL)
+                    .regionId(localCurrencyVO.getRegionId())
+                    .build();
+            List<BadgeVO> byFilter = badgeMapper.findByFilter(badgeFilterDTO);
+
+            if (memberBadgeService.validateMemberBadge(userId, byFilter.get(0).getBadgeId(), BadgeGrade.BRONZE)){
+                MemberBadgeCreateDTO memberBadgeCreateDTO = MemberBadgeCreateDTO.builder()
+                        .badgeId(byFilter.get(0).getBadgeId())
+                        .badgeGrade(BadgeGrade.BRONZE)
+                        .memberId(userId)
+                        .build();
+                memberBadgeService.createMemberBadge(memberBadgeCreateDTO);
+            }
+        }
+        else if (paymentAmount > silver_criteria && paymentAmount < gold_criteria){
+            BadgeFilterDTO badgeFilterDTO = BadgeFilterDTO.builder().badgeType(BadgeType.NORMAL)
+                    .regionId(localCurrencyVO.getRegionId())
+                    .build();
+            List<BadgeVO> byFilter = badgeMapper.findByFilter(badgeFilterDTO);
+
+            if (memberBadgeService.validateMemberBadge(userId, byFilter.get(0).getBadgeId(), BadgeGrade.SILVER)){
+                MemberBadgeCreateDTO memberBadgeCreateDTO = MemberBadgeCreateDTO.builder()
+                        .badgeId(byFilter.get(0).getBadgeId())
+                        .badgeGrade(BadgeGrade.SILVER)
+                        .memberId(userId)
+                        .build();
+                memberBadgeService.createMemberBadge(memberBadgeCreateDTO);
+            }
+
+        }
+        else if (paymentAmount > gold_criteria){
+            BadgeFilterDTO badgeFilterDTO = BadgeFilterDTO.builder().badgeType(BadgeType.NORMAL)
+                    .regionId(localCurrencyVO.getRegionId())
+                    .build();
+            List<BadgeVO> byFilter = badgeMapper.findByFilter(badgeFilterDTO);
+
+            if (memberBadgeService.validateMemberBadge(userId, byFilter.get(0).getBadgeId(), BadgeGrade.GOLD)){
+                MemberBadgeCreateDTO memberBadgeCreateDTO = MemberBadgeCreateDTO.builder()
+                        .badgeId(byFilter.get(0).getBadgeId())
+                        .badgeGrade(BadgeGrade.GOLD)
+                        .memberId(userId)
+                        .build();
+                memberBadgeService.createMemberBadge(memberBadgeCreateDTO);
+            }
+        }
 
         TransactionVO LocalTx = transactionConverter.toTransactionVO(
                 UUID.randomUUID(),

--- a/src/main/java/org/danji/wallet/domain/WalletVO.java
+++ b/src/main/java/org/danji/wallet/domain/WalletVO.java
@@ -21,4 +21,5 @@ public class WalletVO extends BaseVO {
     private WalletType walletType;
     private Integer balance;
     private int displayOrder;
+    private int totalPayment;
 }

--- a/src/main/resources/org/danji/memberBadge/mapper/MemberBadgeMapper.xml
+++ b/src/main/resources/org/danji/memberBadge/mapper/MemberBadgeMapper.xml
@@ -38,11 +38,12 @@
         </where>
     </select>
 
-    <select id="findByMemberIdAndBadgeId" resultType="MemberBadgeVO">
+    <select id="findByMemberIdAndBadgeIdAndBadgeGrade" resultType="MemberBadgeVO">
         SELECT *
         FROM member_badge
         WHERE member_id = #{memberId}
         AND badge_id = #{badgeId}
+        AND badge_grade = #{badgeGrade}
     </select>
 
 


### PR DESCRIPTION
## ✨ 주요 변경 사항

- 결제가 될때마다, total_payment 필드를 조회하여 일정 금액 이상이면 뱃지를 지급하는 로직 구현

## 🔗 관련 이슈
- #126 

## 🔧 PR 종류 (하나만 선택해주세요)
- [ ] 기능 개선 (기존 기능의 동작/성능 향상)
- [ ] 새로운 기능 추가 (신규 도메인, 기능 등)
- [ ] 리팩토링 (동작 변경 없음, 구조 개선)
- [ ] 문서 수정 (README, API 문서 등)
- [ ] 테스트 추가 / 수정
- [ ] 인프라 구성 변경 (Kafka, AWS 리소스 등)
- [ ] 기타

## 📗 참고 자료 (선택)

## 📢 리뷰 요구 사항 (선택)

## ✅ 셀프 체크리스트
- [ ] PR 제목을 형식에 맞게 작성했나요?
- [ ] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요?
- [ ] Assignees, Reviewers, Labels 를 등록했나요?
- [ ] 작업 도중 문서 수정이 필요한 경우 잘 수정했나요?
- [ ] 직접 기능 테스트를 진행했나요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 지역 화폐 지갑 누적 결제 금액에 따라 브론즈, 실버, 골드 등급의 뱃지가 자동으로 지급됩니다.

* **버그 수정**
  * 뱃지 유효성 검증이 등급 기준까지 반영되도록 개선되었습니다.

* **기타**
  * 지갑에 누적 결제 금액 정보가 추가되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->