### PR TITLE
fix: 로그인, 회원가입 시 토큰 넣어서 반환

### DIFF
--- a/src/main/java/org/danji/member/controller/MemberController.java
+++ b/src/main/java/org/danji/member/controller/MemberController.java
@@ -27,21 +27,22 @@ public class MemberController {
     // @ModelAttribute 생략됨 -> formdata 형태로 요청이 올 때 이미지를 받기 위해
     @PostMapping()
     public ResponseEntity<ApiResponse<MemberDTO>> join(@RequestBody MemberJoinDTO member) {
+        MemberDTO memberDTO = service.join(member);
+        String jwt = jwtProcessor.generateToken(memberDTO);
+        memberDTO.setAccessToken(jwt);
+
         return ResponseEntity.status(HttpStatus.CREATED)
-                .body(ApiResponse.success(service.join(member)));
+                .body(ApiResponse.success(memberDTO));
     }
 
     @PostMapping("/login")
     public ResponseEntity<ApiResponse<MemberDTO>> login(@RequestBody LoginDTO loginDTO) {
         MemberDTO memberDTO = service.login(loginDTO);
         String jwt = jwtProcessor.generateToken(memberDTO);;
-
-        HttpHeaders headers = new HttpHeaders();
-        headers.setBearerAuth(jwt);
+        memberDTO.setAccessToken(jwt);
 
         return ResponseEntity
                 .status(HttpStatus.CREATED)
-                .headers(headers)
                 .body(ApiResponse.success(memberDTO));
     }
 

--- a/src/main/java/org/danji/member/dto/MemberDTO.java
+++ b/src/main/java/org/danji/member/dto/MemberDTO.java
@@ -24,6 +24,8 @@ public class MemberDTO extends BaseDTO {
     private Role role;
     private String name;
 
+    private String accessToken;
+
     public static MemberDTO of(MemberVO m) {
         return MemberDTO.builder()
                 .memberId(m.getMemberId())


### PR DESCRIPTION
## 💡 PR 제목
[type] : <기능 또는 변경 요약>

## ✨ 주요 변경 사항

- 어떤 기능이 추가되었고, 어떤 이슈/버그가 해결되었는지 간결하고 명확하게 설명해주세요.

로그인, 회원가입 시 accessToken을 memberDTO에 받아서 반환

## 🔗 관련 이슈
- 연결된 이슈 번호를 입력해주세요 (예: `#42`)
- 없을 경우 생략 가능

## 🔧 PR 종류 (하나만 선택해주세요)
- [x] 기능 개선 (기존 기능의 동작/성능 향상)
- [ ] 새로운 기능 추가 (신규 도메인, 기능 등)
- [ ] 리팩토링 (동작 변경 없음, 구조 개선)
- [ ] 문서 수정 (README, API 문서 등)
- [ ] 테스트 추가 / 수정
- [ ] 인프라 구성 변경 (Kafka, AWS 리소스 등)
- [ ] 기타

## 📗 참고 자료 (선택)

## 📢 리뷰 요구 사항 (선택)

## ✅ 셀프 체크리스트
- [ ] PR 제목을 형식에 맞게 작성했나요?
- [ ] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요?
- [ ] Assignees, Reviewers, Labels 를 등록했나요?
- [ ] 작업 도중 문서 수정이 필요한 경우 잘 수정했나요?
- [ ] 직접 기능 테스트를 진행했나요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * 회원가입 및 로그인 응답에 JWT 액세스 토큰이 포함되어 반환됩니다.

* **변경 사항**
  * JWT 토큰이 더 이상 HTTP 헤더가 아닌 응답 본문 내에 포함되어 전달됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->