### PR TITLE
[refactor] : createMemberBadge 반환 타입 변경

### DIFF
--- a/src/main/java/org/danji/memberBadge/dto/MemberBadgeDTO.java
+++ b/src/main/java/org/danji/memberBadge/dto/MemberBadgeDTO.java
@@ -1,0 +1,32 @@
+package org.danji.memberBadge.dto;
+
+import lombok.*;
+import lombok.experimental.SuperBuilder;
+import org.danji.global.domain.BaseVO;
+import org.danji.memberBadge.domain.MemberBadgeVO;
+import org.danji.memberBadge.enums.BadgeGrade;
+import org.danji.wallet.dto.WalletDTO;
+
+import java.util.UUID;
+
+@NoArgsConstructor
+@AllArgsConstructor
+@Data
+@Builder
+public class MemberBadgeDTO{
+
+    private UUID memberBadgeId;
+    private UUID memberId;
+    private UUID badgeId;
+    private BadgeGrade badgeGrade;
+
+    public static MemberBadgeDTO of(MemberBadgeVO vo) {
+        return vo == null ? null : MemberBadgeDTO.builder()
+                .memberBadgeId(vo.getMemberBadgeId())
+                .memberId(vo.getMemberId())
+                .badgeId(vo.getBadgeId())
+                .badgeGrade(vo.getBadgeGrade())
+                .build();
+
+    }
+}

--- a/src/main/java/org/danji/memberBadge/service/MemberBadgeService.java
+++ b/src/main/java/org/danji/memberBadge/service/MemberBadgeService.java
@@ -1,6 +1,7 @@
 package org.danji.memberBadge.service;
 
 import org.danji.memberBadge.dto.MemberBadgeCreateDTO;
+import org.danji.memberBadge.dto.MemberBadgeDTO;
 import org.danji.memberBadge.dto.MemberBadgeDetailDTO;
 import org.danji.memberBadge.dto.MemberBadgeFilterDTO;
 import org.danji.memberBadge.enums.BadgeGrade;
@@ -10,7 +11,7 @@ import java.util.UUID;
 
 public interface MemberBadgeService {
 
-    MemberBadgeDetailDTO createMemberBadge(MemberBadgeCreateDTO createDTO);
+    MemberBadgeDTO createMemberBadge(MemberBadgeCreateDTO createDTO);
 
     MemberBadgeDetailDTO getMemberBadge(UUID memberBadgeId);
 

--- a/src/main/java/org/danji/memberBadge/service/MemberBadgeServiceImpl.java
+++ b/src/main/java/org/danji/memberBadge/service/MemberBadgeServiceImpl.java
@@ -4,6 +4,7 @@ import lombok.RequiredArgsConstructor;
 import org.danji.global.error.ErrorCode;
 import org.danji.memberBadge.domain.MemberBadgeVO;
 import org.danji.memberBadge.dto.MemberBadgeCreateDTO;
+import org.danji.memberBadge.dto.MemberBadgeDTO;
 import org.danji.memberBadge.dto.MemberBadgeDetailDTO;
 import org.danji.memberBadge.dto.MemberBadgeFilterDTO;
 import org.danji.memberBadge.enums.BadgeGrade;
@@ -23,7 +24,7 @@ public class MemberBadgeServiceImpl implements MemberBadgeService {
 
     @Override
     @Transactional
-    public MemberBadgeDetailDTO createMemberBadge(MemberBadgeCreateDTO createDTO) {
+    public MemberBadgeDTO createMemberBadge(MemberBadgeCreateDTO createDTO) {
         //validateMemberBadge(createDTO.getMemberId(), createDTO.getBadgeId());
         MemberBadgeVO vo = createDTO.toVo();
 
@@ -31,7 +32,7 @@ public class MemberBadgeServiceImpl implements MemberBadgeService {
         vo.setMemberBadgeId(memberBadgeId);
 
         mapper.insert(vo);
-        return getMemberBadge(memberBadgeId);
+        return MemberBadgeDTO.of(vo);
     }
 
     @Override


### PR DESCRIPTION
## ✨ 주요 변경 사항

- createMemberBadge 반환 타입 MemberBadgeDetailDTO 에서 MemberBadgeDTO 로 변경

## 🔗 관련 이슈
- 연결된 이슈 번호를 입력해주세요 (예: `#42`)
- 없을 경우 생략 가능

## 🔧 PR 종류 (하나만 선택해주세요)
- [ ] 기능 개선 (기존 기능의 동작/성능 향상)
- [ ] 새로운 기능 추가 (신규 도메인, 기능 등)
- [ ] 리팩토링 (동작 변경 없음, 구조 개선)
- [ ] 문서 수정 (README, API 문서 등)
- [ ] 테스트 추가 / 수정
- [ ] 인프라 구성 변경 (Kafka, AWS 리소스 등)
- [ ] 기타

## 📗 참고 자료 (선택)

## 📢 리뷰 요구 사항 (선택)

## ✅ 셀프 체크리스트
- [ ] PR 제목을 형식에 맞게 작성했나요?
- [ ] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요?
- [ ] Assignees, Reviewers, Labels 를 등록했나요?
- [ ] 작업 도중 문서 수정이 필요한 경우 잘 수정했나요?
- [ ] 직접 기능 테스트를 진행했나요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 회원 배지 정보를 담는 MemberBadgeDTO가 추가되었습니다.

* **리팩터링**
  * 회원 배지 생성 시 반환 타입이 MemberBadgeDetailDTO에서 MemberBadgeDTO로 변경되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->