### PR TITLE
fix: 결제 내역 조회 날짜 쿼리 오늘 내용까지 조회로 수정

### DIFF
--- a/src/main/resources/org/danji/transaction/mapper/TransactionMapper.xml
+++ b/src/main/resources/org/danji/transaction/mapper/TransactionMapper.xml
@@ -35,7 +35,7 @@
         SELECT *
         FROM transaction
         WHERE owner_wallet_id = #{walletId}
-        AND created_at BETWEEN #{startDate} AND #{lastDate}
+        AND created_at BETWEEN #{startDate} AND DATE_ADD(#{lastDate}, INTERVAL 1 DAY)
 
         <if test="direction != null">
             AND direction = #{direction}


### PR DESCRIPTION
## 💡 PR 제목
[type] : <기능 또는 변경 요약>

## ✨ 주요 변경 사항

- 어떤 기능이 추가되었고, 어떤 이슈/버그가 해결되었는지 간결하고 명확하게 설명해주세요.

## 🔗 관련 이슈
- 연결된 이슈 번호를 입력해주세요 (예: `#42`)
- 없을 경우 생략 가능

## 🔧 PR 종류 (하나만 선택해주세요)
- [ ] 기능 개선 (기존 기능의 동작/성능 향상)
- [ ] 새로운 기능 추가 (신규 도메인, 기능 등)
- [ ] 리팩토링 (동작 변경 없음, 구조 개선)
- [ ] 문서 수정 (README, API 문서 등)
- [ ] 테스트 추가 / 수정
- [ ] 인프라 구성 변경 (Kafka, AWS 리소스 등)
- [ ] 기타

## 📗 참고 자료 (선택)

## 📢 리뷰 요구 사항 (선택)

## ✅ 셀프 체크리스트
- [ ] PR 제목을 형식에 맞게 작성했나요?
- [ ] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요?
- [ ] Assignees, Reviewers, Labels 를 등록했나요?
- [ ] 작업 도중 문서 수정이 필요한 경우 잘 수정했나요?
- [ ] 직접 기능 테스트를 진행했나요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* 버그 수정
  * 거래 내역 기간 필터에서 종료일이 일부만 포함되던 문제를 수정했습니다. 이제 사용자가 선택한 마지막 날짜의 23:59:59까지 결과가 정상적으로 반환됩니다.
  * 기간 검색의 누락 건이 해소되어 조회 일관성과 정확성이 향상되었습니다. 보고서/리스트 등 거래 검색 기능 전반에 동일하게 적용됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->